### PR TITLE
setup: rest exception

### DIFF
--- a/src/main/java/com/egomogo/api/global/exception/RestExceptionHandler.java
+++ b/src/main/java/com/egomogo/api/global/exception/RestExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.egomogo.api.global.exception;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleRestException(ApiException ex, HttpServletRequest request) {
+        return ResponseEntity.status(ex.getHttpStatus())
+                .body(new ErrorResponse(ex, request.getRequestURI()));
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/base/ApiException.java
+++ b/src/main/java/com/egomogo/api/global/exception/base/ApiException.java
@@ -1,0 +1,23 @@
+package com.egomogo.api.global.exception.base;
+
+import com.egomogo.api.global.exception.model.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class ApiException extends RuntimeException{
+    private final HttpStatus httpStatus;
+    private final ErrorCode errorCode;
+
+    public ApiException(HttpStatus httpStatus, ErrorCode errorCode, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+    }
+
+    public ApiException(HttpStatus httpStatus, ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/base/ApiException.java
+++ b/src/main/java/com/egomogo/api/global/exception/base/ApiException.java
@@ -6,18 +6,28 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public abstract class ApiException extends RuntimeException{
-    private final HttpStatus httpStatus;
     private final ErrorCode errorCode;
 
-    public ApiException(HttpStatus httpStatus, ErrorCode errorCode, String message) {
+    public ApiException(ErrorCode errorCode, String message) {
         super(message);
-        this.httpStatus = httpStatus;
         this.errorCode = errorCode;
     }
 
-    public ApiException(HttpStatus httpStatus, ErrorCode errorCode) {
+    public ApiException(ErrorCode errorCode) {
         super(errorCode.getMessage());
-        this.httpStatus = httpStatus;
         this.errorCode = errorCode;
     }
+
+    public ApiException(String message) {
+        super(message);
+        this.errorCode = getDefaultErrorCode();
+    }
+
+    public ApiException() {
+        this.errorCode = getDefaultErrorCode();
+    }
+
+    public abstract HttpStatus getHttpStatus();
+    protected abstract ErrorCode getDefaultErrorCode();
+
 }

--- a/src/main/java/com/egomogo/api/global/exception/impl/BadRequest.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/BadRequest.java
@@ -1,0 +1,16 @@
+package com.egomogo.api.global.exception.impl;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public final class BadRequest extends ApiException {
+
+    public BadRequest(ErrorCode errorCode, String message) {
+        super(HttpStatus.BAD_REQUEST, errorCode, message);
+    }
+
+    public BadRequest(ErrorCode errorCode) {
+        super(HttpStatus.BAD_REQUEST, errorCode);
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/impl/BadRequest.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/BadRequest.java
@@ -5,12 +5,29 @@ import com.egomogo.api.global.exception.model.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public final class BadRequest extends ApiException {
-
     public BadRequest(ErrorCode errorCode, String message) {
-        super(HttpStatus.BAD_REQUEST, errorCode, message);
+        super(errorCode, message);
     }
 
     public BadRequest(ErrorCode errorCode) {
-        super(HttpStatus.BAD_REQUEST, errorCode);
+        super(errorCode);
+    }
+
+    public BadRequest(String message) {
+        super(message);
+    }
+
+    public BadRequest() {
+        super();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    protected ErrorCode getDefaultErrorCode() {
+        return ErrorCode.BAD_REQUEST;
     }
 }

--- a/src/main/java/com/egomogo/api/global/exception/impl/Forbidden.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/Forbidden.java
@@ -5,12 +5,29 @@ import com.egomogo.api.global.exception.model.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public final class Forbidden extends ApiException {
-
     public Forbidden(ErrorCode errorCode, String message) {
-        super(HttpStatus.FORBIDDEN, errorCode, message);
+        super(errorCode, message);
     }
 
     public Forbidden(ErrorCode errorCode) {
-        super(HttpStatus.FORBIDDEN, errorCode);
+        super(errorCode);
+    }
+
+    public Forbidden(String message) {
+        super(message);
+    }
+
+    public Forbidden() {
+        super();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+
+    @Override
+    protected ErrorCode getDefaultErrorCode() {
+        return ErrorCode.FORBIDDEN;
     }
 }

--- a/src/main/java/com/egomogo/api/global/exception/impl/Forbidden.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/Forbidden.java
@@ -1,0 +1,16 @@
+package com.egomogo.api.global.exception.impl;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public final class Forbidden extends ApiException {
+
+    public Forbidden(ErrorCode errorCode, String message) {
+        super(HttpStatus.FORBIDDEN, errorCode, message);
+    }
+
+    public Forbidden(ErrorCode errorCode) {
+        super(HttpStatus.FORBIDDEN, errorCode);
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/impl/InternalServerError.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/InternalServerError.java
@@ -5,12 +5,29 @@ import com.egomogo.api.global.exception.model.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public final class InternalServerError extends ApiException {
-
     public InternalServerError(ErrorCode errorCode, String message) {
-        super(HttpStatus.INTERNAL_SERVER_ERROR, errorCode, message);
+        super(errorCode, message);
     }
 
     public InternalServerError(ErrorCode errorCode) {
-        super(HttpStatus.INTERNAL_SERVER_ERROR, errorCode);
+        super(errorCode);
+    }
+
+    public InternalServerError(String message) {
+        super(message);
+    }
+
+    public InternalServerError() {
+        super();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    protected ErrorCode getDefaultErrorCode() {
+        return ErrorCode.INTERNAL_SERVER_ERROR;
     }
 }

--- a/src/main/java/com/egomogo/api/global/exception/impl/InternalServerError.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/InternalServerError.java
@@ -1,0 +1,16 @@
+package com.egomogo.api.global.exception.impl;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public final class InternalServerError extends ApiException {
+
+    public InternalServerError(ErrorCode errorCode, String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, errorCode, message);
+    }
+
+    public InternalServerError(ErrorCode errorCode) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, errorCode);
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/impl/NotFound.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/NotFound.java
@@ -1,0 +1,16 @@
+package com.egomogo.api.global.exception.impl;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public final class NotFound extends ApiException {
+
+    public NotFound(ErrorCode errorCode, String message) {
+        super(HttpStatus.NOT_FOUND, errorCode, message);
+    }
+
+    public NotFound(ErrorCode errorCode) {
+        super(HttpStatus.NOT_FOUND, errorCode);
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/impl/NotFound.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/NotFound.java
@@ -5,12 +5,31 @@ import com.egomogo.api.global.exception.model.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public final class NotFound extends ApiException {
-
     public NotFound(ErrorCode errorCode, String message) {
-        super(HttpStatus.NOT_FOUND, errorCode, message);
+        super(errorCode, message);
     }
 
     public NotFound(ErrorCode errorCode) {
-        super(HttpStatus.NOT_FOUND, errorCode);
+        super(errorCode);
     }
+
+    public NotFound(String message) {
+        super(message);
+    }
+
+    public NotFound() {
+        super();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    protected ErrorCode getDefaultErrorCode() {
+        return ErrorCode.NOT_FOUND;
+    }
+
+
 }

--- a/src/main/java/com/egomogo/api/global/exception/impl/NotImplemented.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/NotImplemented.java
@@ -5,12 +5,29 @@ import com.egomogo.api.global.exception.model.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public final class NotImplemented extends ApiException {
-
     public NotImplemented(ErrorCode errorCode, String message) {
-        super(HttpStatus.NOT_IMPLEMENTED, errorCode, message);
+        super(errorCode, message);
     }
 
     public NotImplemented(ErrorCode errorCode) {
-        super(HttpStatus.NOT_IMPLEMENTED, errorCode);
+        super(errorCode);
+    }
+
+    public NotImplemented(String message) {
+        super(message);
+    }
+
+    public NotImplemented() {
+        super();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_IMPLEMENTED;
+    }
+
+    @Override
+    protected ErrorCode getDefaultErrorCode() {
+        return ErrorCode.NOT_IMPLEMENTED;
     }
 }

--- a/src/main/java/com/egomogo/api/global/exception/impl/NotImplemented.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/NotImplemented.java
@@ -1,0 +1,16 @@
+package com.egomogo.api.global.exception.impl;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public final class NotImplemented extends ApiException {
+
+    public NotImplemented(ErrorCode errorCode, String message) {
+        super(HttpStatus.NOT_IMPLEMENTED, errorCode, message);
+    }
+
+    public NotImplemented(ErrorCode errorCode) {
+        super(HttpStatus.NOT_IMPLEMENTED, errorCode);
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/impl/Unauthorized.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/Unauthorized.java
@@ -1,0 +1,16 @@
+package com.egomogo.api.global.exception.impl;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import com.egomogo.api.global.exception.model.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public final class Unauthorized extends ApiException {
+
+    public Unauthorized(ErrorCode errorCode, String message) {
+        super(HttpStatus.UNAUTHORIZED, errorCode, message);
+    }
+
+    public Unauthorized(ErrorCode errorCode) {
+        super(HttpStatus.UNAUTHORIZED, errorCode);
+    }
+}

--- a/src/main/java/com/egomogo/api/global/exception/impl/Unauthorized.java
+++ b/src/main/java/com/egomogo/api/global/exception/impl/Unauthorized.java
@@ -5,12 +5,29 @@ import com.egomogo.api.global.exception.model.ErrorCode;
 import org.springframework.http.HttpStatus;
 
 public final class Unauthorized extends ApiException {
-
     public Unauthorized(ErrorCode errorCode, String message) {
-        super(HttpStatus.UNAUTHORIZED, errorCode, message);
+        super(errorCode, message);
     }
 
     public Unauthorized(ErrorCode errorCode) {
-        super(HttpStatus.UNAUTHORIZED, errorCode);
+        super(errorCode);
+    }
+
+    public Unauthorized(String message) {
+        super(message);
+    }
+
+    public Unauthorized() {
+        super();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+
+    @Override
+    protected ErrorCode getDefaultErrorCode() {
+        return ErrorCode.UNAUTHORIZED;
     }
 }

--- a/src/main/java/com/egomogo/api/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/egomogo/api/global/exception/model/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.egomogo.api.global.exception.model;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    SAMPLE("Write a default message if it is required");
+
+    private final String message;
+
+    ErrorCode() {
+        this.message = "";
+    }
+    ErrorCode(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/egomogo/api/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/egomogo/api/global/exception/model/ErrorCode.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-    // Basic Code
+    // Not Unique to use
     NOT_FOUND,
     BAD_REQUEST,
     FORBIDDEN,

--- a/src/main/java/com/egomogo/api/global/exception/model/ErrorCode.java
+++ b/src/main/java/com/egomogo/api/global/exception/model/ErrorCode.java
@@ -4,7 +4,16 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-    SAMPLE("Write a default message if it is required");
+    // Basic Code
+    NOT_FOUND,
+    BAD_REQUEST,
+    FORBIDDEN,
+    INTERNAL_SERVER_ERROR,
+    NOT_IMPLEMENTED,
+    UNAUTHORIZED,
+
+    // Unique for each APIs
+    SOMETHING_BAD("Write a default message if it is required"); // this is a sample
 
     private final String message;
 

--- a/src/main/java/com/egomogo/api/global/exception/model/ErrorResponse.java
+++ b/src/main/java/com/egomogo/api/global/exception/model/ErrorResponse.java
@@ -1,0 +1,21 @@
+package com.egomogo.api.global.exception.model;
+
+import com.egomogo.api.global.exception.base.ApiException;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ErrorResponse {
+    private final LocalDateTime timestamp;
+    private final String errorCode;
+    private final String errorMessage;
+    private final String path;
+
+    public ErrorResponse(ApiException ex, String requestUri) {
+        this.timestamp = LocalDateTime.now();
+        this.errorCode = ex.getErrorCode().name();
+        this.errorMessage = ex.getMessage();
+        this.path = requestUri;
+    }
+}


### PR DESCRIPTION
Setup RestException package

# Package

- global
  - exception
    - base : exception의 최상위 클래스 패키지
    - impl : Http status에 따른 exception 구현체 클래스 패키지
    - model : 에러메시지를 반환하는 DTO 및 에러타입이 위치하는 패키지

# Usage

1. 각 API 명세에 따른 ErrorCode를 global.exception.model.ErrorCode에 추가.

```java
@Getter
public enum ErrorCode {
    // Not unique to use
    NOT_FOUND,
    BAD_REQUEST,
    FORBIDDEN,
    INTERNAL_SERVER_ERROR,
    NOT_IMPLEMENTED,
    UNAUTHORIZED,

    // Unique for each APIs
    SOMETHING_BAD("Write a default message if it is required"); // this is a sample

}
```

2. 서비스 레이어에서 사용.

```java
@Transactional
public RestaurantDto someServiceMethod(...) {
    // ...
    if (SOMETHING_BAD) {
        throw new BadRequest(ErrorCode.SOMETHING_BAD);
    }
    // ...
}
```

# Rule

ErrorCode 중에 HttpStatus와 대응되는 [`NOT_FOUND`, `BAD_REQUEST`, `FORBIDDEN`, `INTERNAL_SERVER_ERROR`, `NOT_IMPLEMENTED`, `UNAUTHORIZED`] 이외에는 각 API에 대해 유일하게 사용되어야 한다.

이외에 여러 API에서 공통적으로 사용될만한 ErrorCode가 있다면 리팩터링 시 추가한다.