### PR TITLE
Fix the bug that select random restaurants with categories

### DIFF
--- a/api/src/test/java/com/egomogo/api/service/appservice/RestaurantServiceImplUnitTest.java
+++ b/api/src/test/java/com/egomogo/api/service/appservice/RestaurantServiceImplUnitTest.java
@@ -3,7 +3,11 @@ package com.egomogo.api.service.appservice;
 import com.egomogo.api.global.adapter.webclient.KakaoWebClientComponent;
 import com.egomogo.api.global.adapter.webclient.dto.CoordinateDto;
 import com.egomogo.api.service.dto.restaurant.SaveRestaurantJson;
+import com.egomogo.domain.dto.IRestaurantDistanceDto;
+import com.egomogo.domain.dto.IRestaurantDistanceDtoImpl;
+import com.egomogo.domain.entity.Menu;
 import com.egomogo.domain.entity.Restaurant;
+import com.egomogo.domain.repository.MenuRepository;
 import com.egomogo.domain.repository.RestaurantRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -12,11 +16,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +32,8 @@ public class RestaurantServiceImplUnitTest {
     private RestaurantServiceImpl restaurantService;
     @Mock
     private RestaurantRepository restaurantRepository;
+    @Mock
+    private MenuRepository menuRepository;
     @Mock
     private KakaoWebClientComponent kakaoWebClientComponent;
 
@@ -59,4 +67,123 @@ public class RestaurantServiceImplUnitTest {
         Assertions.assertEquals(3, result);
     }
 
+    @Test
+    @DisplayName("랜덤 매장 조회 - 전체 카테고리 조회")
+    void test_getRandomRestaurants_allCategories() {
+        // given
+        given(restaurantRepository.findByRandomAndDistance(anyLong(), anyDouble(), anyDouble(), anyInt(), any()))
+                .willReturn(new SliceImpl<>(List.of(
+                                IRestaurantDistanceDtoImpl.builder()
+                                        .id("rid-1")
+                                        .name("restaurant-1")
+                                        .address("address-1")
+                                        .x(127.123132)
+                                        .y(37.123123)
+                                        .distance(500).build(),
+                                IRestaurantDistanceDtoImpl.builder()
+                                        .id("rid-2")
+                                        .name("restaurant-2")
+                                        .address("address-2")
+                                        .x(127.123132)
+                                        .y(37.123123)
+                                        .distance(500).build(),
+                                IRestaurantDistanceDtoImpl.builder()
+                                        .id("rid-3")
+                                        .name("restaurant-3")
+                                        .address("address-3")
+                                        .x(127.123132)
+                                        .y(37.123123)
+                                        .distance(500).build())));
+        given(menuRepository.findTop3ByRestaurantId(anyString()))
+                .willReturn(List.of(
+                        Menu.builder()
+                                .id("mid-1")
+                                .name("menu-1")
+                                .price("price-1").build(),
+                        Menu.builder()
+                                .id("mid-2")
+                                .name("menu-2")
+                                .price("price-2").build(),
+                        Menu.builder()
+                                .id("mid-3")
+                                .name("menu-3")
+                                .price("price-3").build()));
+        // when
+        Slice<IRestaurantDistanceDto> result = restaurantService.getRandomRestaurants(
+                12345L, List.of(), 123.1231, 37.1232231, 1000, PageRequest.of(0, 10));
+        // then
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(3, result.getContent().size());
+        Assertions.assertEquals(3, result.getContent().get(0).getMenus().size());
+        Assertions.assertEquals(3, result.getContent().get(1).getMenus().size());
+        Assertions.assertEquals(3, result.getContent().get(2).getMenus().size());
+    }
+
+    @Test
+    @DisplayName("랜덤 매장 조회 - 특정 카테고리 조회")
+    void test_getRandomRestaurants_with_categories() {
+        // given
+        given(restaurantRepository.findByRandomAndDistanceAndCategories(anyLong(), anyDouble(), anyDouble(), anyInt(), anyCollection(), any()))
+                .willReturn(new SliceImpl<>(List.of(
+                        IRestaurantDistanceDtoImpl.builder()
+                                .id("rid-1")
+                                .name("restaurant-1")
+                                .address("address-1")
+                                .x(127.123132)
+                                .y(37.123123)
+                                .distance(500).build(),
+                        IRestaurantDistanceDtoImpl.builder()
+                                .id("rid-2")
+                                .name("restaurant-2")
+                                .address("address-2")
+                                .x(127.123132)
+                                .y(37.123123)
+                                .distance(500).build(),
+                        IRestaurantDistanceDtoImpl.builder()
+                                .id("rid-3")
+                                .name("restaurant-3")
+                                .address("address-3")
+                                .x(127.123132)
+                                .y(37.123123)
+                                .distance(500).build())));
+        given(menuRepository.findTop3ByRestaurantId(anyString()))
+                .willReturn(List.of(
+                        Menu.builder()
+                                .id("mid-1")
+                                .name("menu-1")
+                                .price("price-1").build(),
+                        Menu.builder()
+                                .id("mid-2")
+                                .name("menu-2")
+                                .price("price-2").build(),
+                        Menu.builder()
+                                .id("mid-3")
+                                .name("menu-3")
+                                .price("price-3").build()));
+        // when
+        Slice<IRestaurantDistanceDto> result = restaurantService.getRandomRestaurants(
+                123L, List.of("KOREAN", "MEAT"), 1.1, 1.1, 100, PageRequest.of(0, 10));
+        // then
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(3, result.getContent().size());
+        Assertions.assertEquals(3, result.getContent().get(0).getMenus().size());
+        Assertions.assertEquals(3, result.getContent().get(1).getMenus().size());
+        Assertions.assertEquals(3, result.getContent().get(2).getMenus().size());
+    }
+
+    @Test
+    @DisplayName("랜덤 매장 조회 - 실패 - 잘못된 카테고리 요청")
+    void test_getRandomRestaurants_with_categories_when_wrong_categories() {
+        // given
+        // when
+        // then
+        IllegalArgumentException ex = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> restaurantService.getRandomRestaurants(
+                        123L, List.of("KOREAN", "MEAT", "WRONG"), 1.1, 1.1, 100, null));
+        Assertions.assertEquals(
+                "Request wrong category name. Request category is WRONG.",
+                ex.getMessage()
+        );
+    }
 }

--- a/api/src/test/java/com/egomogo/api/service/appservice/RestaurantServiceImplUnitTest.java
+++ b/api/src/test/java/com/egomogo/api/service/appservice/RestaurantServiceImplUnitTest.java
@@ -77,23 +77,23 @@ public class RestaurantServiceImplUnitTest {
                                         .id("rid-1")
                                         .name("restaurant-1")
                                         .address("address-1")
-                                        .x(127.123132)
-                                        .y(37.123123)
-                                        .distance(500).build(),
+                                        .x(1.1)
+                                        .y(1.1)
+                                        .distance(100).build(),
                                 IRestaurantDistanceDtoImpl.builder()
                                         .id("rid-2")
                                         .name("restaurant-2")
                                         .address("address-2")
-                                        .x(127.123132)
-                                        .y(37.123123)
-                                        .distance(500).build(),
+                                        .x(2.2)
+                                        .y(2.2)
+                                        .distance(200).build(),
                                 IRestaurantDistanceDtoImpl.builder()
                                         .id("rid-3")
                                         .name("restaurant-3")
                                         .address("address-3")
-                                        .x(127.123132)
-                                        .y(37.123123)
-                                        .distance(500).build())));
+                                        .x(3.3)
+                                        .y(3.3)
+                                        .distance(300).build())));
         given(menuRepository.findTop3ByRestaurantId(anyString()))
                 .willReturn(List.of(
                         Menu.builder()
@@ -114,8 +114,29 @@ public class RestaurantServiceImplUnitTest {
         // then
         Assertions.assertNotNull(result);
         Assertions.assertEquals(3, result.getContent().size());
+
+        Assertions.assertEquals("rid-1", result.getContent().get(0).getId());
+        Assertions.assertEquals("restaurant-1", result.getContent().get(0).getName());
+        Assertions.assertEquals("address-1", result.getContent().get(0).getAddress());
+        Assertions.assertEquals(1.1, result.getContent().get(0).getX());
+        Assertions.assertEquals(1.1, result.getContent().get(0).getY());
+        Assertions.assertEquals(100, result.getContent().get(0).getDistance());
         Assertions.assertEquals(3, result.getContent().get(0).getMenus().size());
+
+        Assertions.assertEquals("rid-2", result.getContent().get(1).getId());
+        Assertions.assertEquals("restaurant-2", result.getContent().get(1).getName());
+        Assertions.assertEquals("address-2", result.getContent().get(1).getAddress());
+        Assertions.assertEquals(2.2, result.getContent().get(1).getX());
+        Assertions.assertEquals(2.2, result.getContent().get(1).getY());
+        Assertions.assertEquals(200, result.getContent().get(1).getDistance());
         Assertions.assertEquals(3, result.getContent().get(1).getMenus().size());
+
+        Assertions.assertEquals("rid-3", result.getContent().get(2).getId());
+        Assertions.assertEquals("restaurant-3", result.getContent().get(2).getName());
+        Assertions.assertEquals("address-3", result.getContent().get(2).getAddress());
+        Assertions.assertEquals(3.3, result.getContent().get(2).getX());
+        Assertions.assertEquals(3.3, result.getContent().get(2).getY());
+        Assertions.assertEquals(300, result.getContent().get(2).getDistance());
         Assertions.assertEquals(3, result.getContent().get(2).getMenus().size());
     }
 
@@ -166,8 +187,29 @@ public class RestaurantServiceImplUnitTest {
         // then
         Assertions.assertNotNull(result);
         Assertions.assertEquals(3, result.getContent().size());
+
+        Assertions.assertEquals("rid-1", result.getContent().get(0).getId());
+        Assertions.assertEquals("restaurant-1", result.getContent().get(0).getName());
+        Assertions.assertEquals("address-1", result.getContent().get(0).getAddress());
+        Assertions.assertEquals(1.1, result.getContent().get(0).getX());
+        Assertions.assertEquals(1.1, result.getContent().get(0).getY());
+        Assertions.assertEquals(100, result.getContent().get(0).getDistance());
         Assertions.assertEquals(3, result.getContent().get(0).getMenus().size());
+
+        Assertions.assertEquals("rid-2", result.getContent().get(1).getId());
+        Assertions.assertEquals("restaurant-2", result.getContent().get(1).getName());
+        Assertions.assertEquals("address-2", result.getContent().get(1).getAddress());
+        Assertions.assertEquals(2.2, result.getContent().get(1).getX());
+        Assertions.assertEquals(2.2, result.getContent().get(1).getY());
+        Assertions.assertEquals(200, result.getContent().get(1).getDistance());
         Assertions.assertEquals(3, result.getContent().get(1).getMenus().size());
+
+        Assertions.assertEquals("rid-3", result.getContent().get(2).getId());
+        Assertions.assertEquals("restaurant-3", result.getContent().get(2).getName());
+        Assertions.assertEquals("address-3", result.getContent().get(2).getAddress());
+        Assertions.assertEquals(3.3, result.getContent().get(2).getX());
+        Assertions.assertEquals(3.3, result.getContent().get(2).getY());
+        Assertions.assertEquals(300, result.getContent().get(2).getDistance());
         Assertions.assertEquals(3, result.getContent().get(2).getMenus().size());
     }
 

--- a/domain/src/main/java/com/egomogo/domain/dto/IRestaurantDistanceDtoImpl.java
+++ b/domain/src/main/java/com/egomogo/domain/dto/IRestaurantDistanceDtoImpl.java
@@ -1,7 +1,12 @@
 package com.egomogo.domain.dto;
 
+import lombok.*;
+
 import java.util.List;
 
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
 public class IRestaurantDistanceDtoImpl implements IRestaurantDistanceDto {
 
     private final String id;

--- a/domain/src/main/java/com/egomogo/domain/repository/RestaurantRepository.java
+++ b/domain/src/main/java/com/egomogo/domain/repository/RestaurantRepository.java
@@ -27,8 +27,10 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, String> 
     @Query(
             value = "SELECT *, " +
                     "ST_Distance_Sphere(POINT(:userX, :userY), POINT(r.x, r.y)) as distance " +
-                    "FROM restaurant as r, restaurant_categories as rc " +
-                    "WHERE rc.categories IN (:categories) " +
+                    "FROM restaurant as r " +
+                    "INNER JOIN " +
+                        "(SELECT distinct restaurant_id FROM restaurant_categories WHERE categories IN (:categories)) as rc " +
+                    "ON r.id = rc.restaurant_id " +
                     "HAVING distance <= :distanceLimit " +
                     "ORDER BY RAND(:seed)",
             nativeQuery = true


### PR DESCRIPTION
### AS-IS
- 카테고리별 매장을 랜덤으로 조회하기 위해 카테고리를 조건으로 쿼리를 보내도, 카테고리에 대한 필터링이 적용되지 않았음.
- 랜덤 매장 조회에 대한 테스트 코드가 없었음.

### TO-BE
- 카테고리 조회를 위한 쿼리를 수정함에 따라 정상적인 작동이 되는 것으로 보임.
```sql
SELECT *, ST_Distance_Sphere(POINT(:userX, :userY), POINT(r.x, r.y)) as distance 
FROM restaurant as r  
  INNER JOIN 
     (SELECT distinct restaurant_id FROM restaurant_categories WHERE categories IN (:categories)) as rc 
  ON r.id = rc.restaurant_id 
HAVING distance <= :distanceLimit 
ORDER BY RAND(:seed)
```
- 랜덤 매장 조회에 대한 테스트 코드 작성함

### TEST
- [x] UNIT TEST
- [x] API TEST (using POSTMAN)

CLOSE #19 