### PR TITLE
Add two attributes of restaurant entity

### DIFF
--- a/domain/sql/schema.sql
+++ b/domain/sql/schema.sql
@@ -9,6 +9,8 @@ CREATE TABLE `restaurant` (
     x float(53) default 0.0 not null ,
     y float(53) default 0.0 not null ,
     kakao_place_id varchar(50) not null ,
+    api_called_at datetime ,
+    scraped_at datetime ,
     created_at datetime not null ,
     updated_at datetime
 );

--- a/domain/src/main/java/com/egomogo/domain/entity/Restaurant.java
+++ b/domain/src/main/java/com/egomogo/domain/entity/Restaurant.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +34,12 @@ public class Restaurant extends BaseAuditEntity {
 
     @Column(name = "kakao_place_id", nullable = false)
     private String kakaoPlaceId;
+
+    @Column(name = "api_called_at")
+    private LocalDateTime apiCalledAt;
+
+    @Column(name = "scarped_at")
+    private LocalDateTime scrapedAt;
 
     @OneToMany(mappedBy = "restaurant", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Menu> menus = new ArrayList<>();


### PR DESCRIPTION
### AS-IS
- Restaurant 엔티티에 Kakao API 호출 시점 및 스크래핑 시점에 대한 정보가 없었음.

### TO-BE
- 관리자 입장에서 언제 마지막으로 API를 호출하였는지, 그리고 메뉴 스크래핑을 하였는지에 대한 시점을 확인할 수 있어서 리소스를 관리하는데에 용이할 수 있음.
- Restaurant 클래스에 `LocalDateTime`을 타입으로 가지는 두 변수를 생성함
```java
private LocalDateTime apiCalledAt;
private LocalDateTime scrapedAt;
```
- DDL에도 위 두 변수에 대한 column을 추가함. 
```sql
   ....
    api_called_at datetime ,
    scraped_at datetime ,
   .....
```

### TEST
- [ ] UNIT TEST
- [ ] API TEST

CLOSE #21 